### PR TITLE
Refactor API to use extract_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,17 @@ API for generating tests.
 python app.py
 ```
 
-Send a POST request to `/generate` with JSON containing either `file_path` or
-`code`.
+Send a POST request to `/generate-tests` with a JSON payload containing a list
+of files. Each file must include a `name` and `content` field. The server will
+extract the methods using the included Java utility and invoke an LLM to
+produce JUnit tests for each file. The response returns a JSON object with a
+Base64-encoded zip archive (`zip`) and the extracted method names.
 
 Example:
 
 ```bash
-curl -X POST http://localhost:8000/generate -H 'Content-Type: application/json' \
-    -d '{"file_path": "HelloWorld.java"}'
+curl -X POST http://localhost:8000/generate-tests -H 'Content-Type: application/json' \
+    -d '{"files": [{"name": "HelloWorld.java", "content": "..."}]}'
 ```
 
-The response contains the generated JUnit test.
+Decode the `zip` field to retrieve the generated test files.

--- a/app.py
+++ b/app.py
@@ -1,51 +1,17 @@
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify
 from extract_method import extract_method
 from junit_test_generator import generate_junit_test
 import os
 import io
 import zipfile
+import base64
+import re
 
 # Add CORS support to allow requests from UI
 from flask_cors import CORS
 
 app = Flask(__name__)
 CORS(app) # Enable CORS for all routes
-
-@app.route('/generate', methods=['POST'])
-def generate():
-    # Check if request has JSON data or form data
-    if request.is_json:
-        data = request.get_json()
-        print("Received JSON data:", data)
-    else:
-        data = request.form.to_dict()
-        print("Received form data:", data)
-
-    if not data:
-        return jsonify({'error': 'No data provided'}), 400
-
-    java_file = None
-    # handle raw code
-    if data.get('code'):
-        java_file = 'TempInput.java'
-        print("Writing code to file:", java_file)
-        with open(java_file, 'w') as f:
-            f.write(data['code'])
-    elif data.get('file_path'):
-        java_file = data['file_path']
-        print("Using file path:", java_file)
-    else:
-        return jsonify({'error': 'Provide code or file_path'}), 400
-
-    method_code = extract_method(java_file)
-    print("Extracted method code:", method_code)
-    if method_code is None:
-        return jsonify({'error': 'Failed to extract method'}), 500
-
-    junit_test = generate_junit_test(method_code)
-    print("Generated JUnit test:", junit_test)
-    return jsonify({'junit_test': junit_test})
-
 
 @app.route('/generate-tests', methods=['POST'])
 def generate_tests():
@@ -71,16 +37,36 @@ def generate_tests():
 
     # Map of output filename to test content
     test_files = {}
-    for file in files:
+    methods_info = {}
+    for idx, file in enumerate(files):
         name = file.get('name')
         content = file.get('content')
         print(f"Processing file: {name}")
         if not name or content is None:
             continue
-        junit = generate_junit_test(content)
+
+        # Write content to a temporary file so ExtractMethod can parse it
+        tmp_name = f"temp_{idx}.java"
+        with open(tmp_name, "w") as tmp_file:
+            tmp_file.write(content)
+
+        # Extract method bodies using the Java utility
+        extracted = extract_method(tmp_name)
+        print(f"Extracted methods from {name}:\n{extracted}")
+        if not extracted:
+            os.remove(tmp_name)
+            continue
+
+        # Collect method names for the response
+        method_names = re.findall(r"\b(\w+)\s*\(", extracted)
+        methods_info[name] = method_names
+
+        junit = generate_junit_test(extracted)
         test_name = name.rsplit('.', 1)[0] + 'Test.java'
         test_files[test_name] = junit
         print(f"Generated test for {name} -> {test_name}")
+
+        os.remove(tmp_name)
 
     mem_zip = io.BytesIO()
     with zipfile.ZipFile(mem_zip, 'w') as zf:
@@ -88,12 +74,9 @@ def generate_tests():
             zf.writestr(fname, code)
             print(f"Added {fname} to zip file")
     mem_zip.seek(0)
-    return send_file(
-        mem_zip,
-        mimetype='application/zip',
-        as_attachment=True,
-        download_name='junit-tests.zip'
-    )
+    zip_b64 = base64.b64encode(mem_zip.getvalue()).decode("utf-8")
+
+    return jsonify({"zip": zip_b64, "methods": methods_info})
 
 if __name__ == '__main__':
     port = int(os.getenv('PORT', 8000))


### PR DESCRIPTION
## Summary
- remove obsolete `/generate` endpoint
- update `/generate-tests` to run the Java extractor and return a base64 zip along with method names
- document new behaviour in README

## Testing
- `python -m py_compile app.py extract_method.py junit_test_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_686cb8303b288322b3ecc67490bfacf0