### PR TITLE
Speed up test generation

### DIFF
--- a/junit_test_generator.py
+++ b/junit_test_generator.py
@@ -90,10 +90,10 @@ def _call_llm(state):
     return {"junit_test": ""}
 
 # Set environment variables for LangSmith
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
-os.environ["LANGCHAIN_API_KEY"] = "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"
-os.environ["LANGCHAIN_PROJECT"] = "JUnit_test_generation"
+os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
+os.environ.setdefault("LANGCHAIN_ENDPOINT", "https://api.smith.langchain.com")
+os.environ.setdefault("LANGCHAIN_API_KEY", "")
+os.environ.setdefault("LANGCHAIN_PROJECT", "JUnit_test_generation")
 
 @traceable(name="generate_junit_test")
 def generate_junit_test(java_method_code):


### PR DESCRIPTION
## Summary
- process each uploaded file concurrently
- compress test bundle with `ZIP_DEFLATED`
- default LangSmith API settings to env variables

## Testing
- `python -m py_compile app.py extract_method.py junit_test_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_686cc94009d8832284a6f17ceee6ae29