### PR TITLE
Speed up test generation

### DIFF
--- a/extract_method.py
+++ b/extract_method.py
@@ -1,16 +1,43 @@
 import subprocess
+import os
+import sys
 
-def extract_method(java_file):
-    # On Windows, use ';' in classpath. On Mac/Linux, use ':'
-    cmd = [
-        'java', '-cp', '.:javaparser-core-3.25.4.jar',
-        'ExtractMethod', java_file
-    ]
+_DIR = os.path.dirname(os.path.abspath(__file__))
+_JAR = os.path.join(_DIR, "javaparser-core-3.25.4.jar")
+_JAVA_FILE = os.path.join(_DIR, "ExtractMethod.java")
+_CLASS_FILE = os.path.join(_DIR, "ExtractMethod.class")
+
+
+def _ensure_compiled():
+    """Compile the ExtractMethod utility if the class file is missing."""
+    if os.path.exists(_CLASS_FILE):
+        return True
+    cmd = ["javac", "-cp", _JAR, _JAVA_FILE]
     result = subprocess.run(
         cmd,
+        cwd=_DIR,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True
+        text=True,
+    )
+    if result.returncode != 0:
+        print("Compile error:", result.stderr, file=sys.stderr)
+        return False
+    return True
+
+
+def extract_method(java_file):
+    """Run the ExtractMethod Java utility on ``java_file``."""
+    if not _ensure_compiled():
+        return None
+    classpath = f"{_DIR}{os.pathsep}{_JAR}"
+    cmd = ["java", "-cp", classpath, "ExtractMethod", java_file]
+    result = subprocess.run(
+        cmd,
+        cwd=_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
     if result.returncode != 0:
         print("Error:", result.stderr)

--- a/junit_test_generator.py
+++ b/junit_test_generator.py
@@ -90,10 +90,10 @@ def _call_llm(state):
     return {"junit_test": ""}
 
 # Set environment variables for LangSmith
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
-os.environ["LANGCHAIN_API_KEY"] = "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"
-os.environ["LANGCHAIN_PROJECT"] = "JUnit_test_generation"
+os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
+os.environ.setdefault("LANGCHAIN_ENDPOINT", "https://api.smith.langchain.com")
+os.environ.setdefault("LANGCHAIN_API_KEY", "")
+os.environ.setdefault("LANGCHAIN_PROJECT", "JUnit_test_generation")
 
 @traceable(name="generate_junit_test")
 def generate_junit_test(java_method_code):


### PR DESCRIPTION
## Summary
- process each uploaded file concurrently
- compress test bundle with `ZIP_DEFLATED`
- default LangSmith API settings to env variables
- run ExtractMethod utility from repo root

## Testing
- `python -m py_compile app.py extract_method.py junit_test_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc94009d8832284a6f17ceee6ae29