### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,25 @@ methods using `javaparser` and generates tests via an LLM.
 
 ## Requirements
 
-Install Python dependencies:
+1. Install the Python dependencies:
 
 ```bash
 pip install -r requirements.txt
 ```
 
+2. Install a Java Development Kit (JDK) so that `java` and `javac` are available.
+   The helper `ExtractMethod.java` is compiled automatically on the first run
+   if `ExtractMethod.class` is missing. Keep `javaparser-core-3.25.4.jar`
+   alongside the sources.
+
+3. Set the required environment variables:
+   - `OPENAI_API_KEY` to enable the OpenAI API.
+   - Optional LangChain/LangSmith variables `LANGCHAIN_TRACING_V2`,
+     `LANGCHAIN_ENDPOINT`, `LANGCHAIN_API_KEY` and `LANGCHAIN_PROJECT`.
+
 The backend optionally integrates with **LangChain** and **LangSmith** for LLM
 invocation and tracing. If these packages are unavailable, the server falls
 back to using the raw OpenAI client.
-
-A Java runtime is required for the `ExtractMethod` class. Make sure the
-`javaparser-core-3.25.4.jar` is present in the repository.
-
-Set the `OPENAI_API_KEY` environment variable if you want to use the OpenAI
-API for generating tests.
 
 ## Running the server
 
@@ -28,17 +32,24 @@ API for generating tests.
 python app.py
 ```
 
-Send a POST request to `/generate-tests` with a JSON payload containing a list
-of files. Each file must include a `name` and `content` field. The server will
-extract the methods using the included Java utility and invoke an LLM to
-produce JUnit tests for each file. The response returns a JSON object with a
-Base64-encoded zip archive (`zip`) and the extracted method names.
+Send a POST request to `/generate-tests` with a list of files. Each file must
+include a `name` and `content` field. The server extracts methods with the
+Java helper and invokes an LLM to produce JUnit tests for each file. The
+response returns a JSON object with a Base64-encoded zip archive (`zip`) and
+the extracted method names.
 
-Example:
+Example JSON request:
 
 ```bash
 curl -X POST http://localhost:8000/generate-tests -H 'Content-Type: application/json' \
     -d '{"files": [{"name": "HelloWorld.java", "content": "..."}]}'
+```
+
+Example multipart/form-data request:
+
+```bash
+curl -X POST http://localhost:8000/generate-tests \
+    -F 'files=[{"name": "HelloWorld.java", "content": "..."}]'
 ```
 
 Decode the `zip` field to retrieve the generated test files.


### PR DESCRIPTION
## Summary
- expand README with JDK requirement and automatic compilation
- mention LangChain/LangSmith env variables
- document form-data upload example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d205ba7c48322980ccf90820fa6a2