### PR TITLE
Remove OpenAI fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ pip install -r requirements.txt
    alongside the sources.
 
 3. Set the required environment variables:
-   - `OPENAI_API_KEY` to enable the OpenAI API.
+   - `OPENAI_API_KEY` for LangChain's ChatOpenAI.
    - Optional LangChain/LangSmith variables `LANGCHAIN_TRACING_V2`,
      `LANGCHAIN_ENDPOINT`, `LANGCHAIN_API_KEY` and `LANGCHAIN_PROJECT`.
 
-The backend optionally integrates with **LangChain** and **LangSmith** for LLM
-invocation and tracing. If these packages are unavailable, the server falls
-back to using the raw OpenAI client.
+The backend relies on **LangChain** and uses `ChatOpenAI` for all LLM
+invocation. LangSmith can be enabled for tracing when the environment
+variables are provided.
 
 ## Running the server
 

--- a/junit_test_generator.py
+++ b/junit_test_generator.py
@@ -2,13 +2,7 @@
 
 from __future__ import annotations
 
-import os
-from typing import Optional
 
-try:
-    import openai
-except ImportError:  # pragma: no cover - openai may not be installed in tests
-    openai = None
 
 try:
     from langchain.chat_models import ChatOpenAI
@@ -33,19 +27,6 @@ def _call_llm(prompt: str) -> str:
         llm = ChatOpenAI(model_name="gpt-4o", max_tokens=800)
         result = llm.invoke(prompt)
         return result.content.strip()
-
-    if openai is not None:
-        api_key = os.getenv("OPENAI_API_KEY")
-        client = openai.OpenAI(api_key=api_key)
-        response = client.chat.completions.create(
-            model="gpt-4o",
-            messages=[
-                {"role": "system", "content": "You are an expert Java test writer."},
-                {"role": "user", "content": prompt},
-            ],
-            max_tokens=800,
-        )
-        return response.choices[0].message.content.strip()
 
     # No language model available
     return ""


### PR DESCRIPTION
## Summary
- always use LangChain ChatOpenAI for LLM calls
- clarify README instructions about ChatOpenAI and tracing

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686d2a061e088322be5733ab2189e3ef