### PR TITLE
Integrate LangSmith tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ pip install -r requirements.txt
 
 The backend relies on **LangChain** and uses `ChatOpenAI` for all LLM
 invocation. LangSmith can be enabled for tracing when the environment
-variables are provided.
+variables are provided. Each request to `/generate-tests` is wrapped in a
+LangSmith `traceable` span so high-level steps appear in the trace along with
+the LLM calls.
 
 ## Running the server
 

--- a/app.py
+++ b/app.py
@@ -12,6 +12,19 @@ import zipfile
 from extract_method import extract_method
 from junit_test_generator import generate_junit_test
 
+try:  # pragma: no cover - langsmith is optional in tests
+    from langsmith import traceable
+except Exception:  # pragma: no cover - langsmith may not be installed
+    def traceable(_func=None, **_kwargs):
+        """Fallback no-op decorator when ``langsmith`` is missing."""
+
+        def decorator(func):
+            return func
+
+        if _func is None:
+            return decorator
+        return decorator(_func)
+
 
 app = Flask(__name__)
 # Allow requests from the browser UI
@@ -68,6 +81,7 @@ def _make_zip(test_files):
 
 
 @app.route("/generate-tests", methods=["POST"])
+@traceable
 def generate_tests():
     """Generate JUnit tests for each file in the request."""
     data = _parse_request(request)

--- a/junit_test_generator.py
+++ b/junit_test_generator.py
@@ -9,6 +9,19 @@ try:
 except Exception:  # pragma: no cover - langchain may not be installed in tests
     ChatOpenAI = None
 
+try:  # pragma: no cover - langsmith is optional in tests
+    from langsmith import traceable
+except Exception:  # pragma: no cover - langsmith may not be installed
+    def traceable(_func=None, **_kwargs):
+        """Fallback no-op decorator when ``langsmith`` is missing."""
+
+        def decorator(func):
+            return func
+
+        if _func is None:
+            return decorator
+        return decorator(_func)
+
 
 def _craft_prompt(method_code: str) -> str:
     """Create the English instructions sent to the model."""
@@ -32,6 +45,7 @@ def _call_llm(prompt: str) -> str:
     return ""
 
 
+@traceable
 def generate_junit_test(java_method_code: str) -> str:
     """Return the JUnit test generated for ``java_method_code``."""
 


### PR DESCRIPTION
## Summary
- add optional `langsmith` import with fallback
- wrap the Flask handler with `@traceable`
- decorate JUnit test generation with `@traceable`
- document tracing behaviour in README

## Testing
- `python -m py_compile app.py extract_method.py junit_test_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2c9966ec832291cf9d1e0d068e68