### PR TITLE
Update env defaults and typing

### DIFF
--- a/extract_method.py
+++ b/extract_method.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import logging
+from typing import Optional
 
 # Paths to the Java helper and library
 _DIR = os.path.dirname(os.path.abspath(__file__))
@@ -36,7 +37,7 @@ def _ensure_compiled() -> bool:
     return True
 
 
-def extract_method(java_file: str) -> str | None:
+def extract_method(java_file: str) -> Optional[str]:
     """Return all methods found in ``java_file`` as text."""
 
     if not _ensure_compiled():

--- a/junit_test_generator.py
+++ b/junit_test_generator.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 
 
 import logging
+import os
+
+os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
+os.environ.setdefault("LANGCHAIN_ENDPOINT", "https://api.smith.langchain.com")
+os.environ.setdefault("LANGCHAIN_API_KEY", "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")
+os.environ.setdefault("LANGCHAIN_PROJECT", "JUnit_test_generation")
 
 try:
     from langchain.chat_models import ChatOpenAI


### PR DESCRIPTION
## Summary
- set default LangChain environment variables in junit_test_generator
- import Optional and update extract_method return type

## Testing
- `python -m py_compile app.py extract_method.py junit_test_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_686d520a24e083229cbe96cc1ff90fd2